### PR TITLE
Select Admin Page Status Message by HTML Class

### DIFF
--- a/core/templates/pages/admin-page/admin-page.directive.html
+++ b/core/templates/pages/admin-page/admin-page.directive.html
@@ -2,7 +2,8 @@
 
 <div align="center"
      ng-if="$ctrl.statusMessage"
-     style="background-color: #ffffff; position: fixed; max-width: 30%; z-index: 3000; border: 1px solid #00376d; right: 30px; bottom: 30px">
+     style="background-color: #ffffff; position: fixed; max-width: 30%; z-index: 3000; border: 1px solid #00376d; right: 30px; bottom: 30px"
+     class="protractor-test-status-message">
   <[$ctrl.statusMessage]>
 </div>
 <br>

--- a/core/tests/protractor_utils/AdminPage.js
+++ b/core/tests/protractor_utils/AdminPage.js
@@ -32,7 +32,7 @@ var AdminPage = function() {
   var updateFormName = element(by.css('.protractor-update-form-name'));
   var updateFormSubmit = element(by.css('.protractor-update-form-submit'));
   var roleSelect = element(by.css('.protractor-update-form-role-select'));
-  var statusMessage = element(by.css('[ng-if="$ctrl.statusMessage"]'));
+  var statusMessage = element(by.css('.protractor-test-status-message'));
 
   // Viewing roles can be done by two methods: 1. By roles 2. By username
   var roleDropdown = element(by.css('.protractor-test-role-method'));


### PR DESCRIPTION
The admin page status message was being selected by an `ng-if` selector.
This commit replaces that with a new HTML class.

Fixes part of #8884.